### PR TITLE
Moved stream reading to Audio

### DIFF
--- a/C++/Audio.h
+++ b/C++/Audio.h
@@ -1,6 +1,9 @@
 #include "portaudio.h"
+
 #include <iostream>
 #include <sndfile.h>
+#include <vector>
+#include <cstring>
 
 class AudioUtil;
 
@@ -9,16 +12,21 @@ class Audio {
 	public:
 		Audio(int channelCount, int sampleRate, int framesPerBuffer);
 		virtual ~Audio();
+		
 		void startStream();
+		void readStream(bool &stop);
 		void stopStream();
-		PaStreamParameters getInputParameters();
-		PaStreamParameters getOutputParameters();
-		const int getSampleRate();
-		const int getFramesPerBuffer();
+
+		bool dataIsEmpty();
+		void dataFlush();
+		
 		void error(PaError errorCode);
+
 	
 	protected:
 		PaStreamParameters inputParameters, outputParameters;
+		std::vector<float> data;
+		SF_INFO sfinfo;
 		const int sampleRate;
 		const int framesPerBuffer;
 		PaStream *stream = NULL;

--- a/C++/AudioUtil.h
+++ b/C++/AudioUtil.h
@@ -1,8 +1,7 @@
 #include "Audio.h"
 
-#include "portaudio.h"
-#include <vector>
-#include <cstring>
+#include <thread>
+#include <chrono>
 
 class AudioUtil : public Audio {
 
@@ -12,12 +11,8 @@ class AudioUtil : public Audio {
 		int record(int seconds);
 		int writeWAV(const char* filename);
 		int readWAV(const char* filename);
-		bool dataIsEmpty();
-		void dataFlush();
 
 	private:
-		std::vector<float> data;
 		SNDFILE *infile, *outfile;
-		SF_INFO sfinfo;
-		int initInfo();
+		
 };


### PR DESCRIPTION
Important Notes:

- This was to try and standardize the purposes of Audio and AudioUtil a bit. Audio should be for lower-level streaming information and AudioUtil should be for higher level understanding of what's going on. 

- The threading in AudioUtil was a pain, because apparently thread parameters cannot be passed by reference by default. That's why, if you look at line 26, the "stop" parameter uses the std::ref() wrapper.

