### PR TITLE
Init commit of AudioFeatures

### DIFF
--- a/C++/Audio.cpp
+++ b/C++/Audio.cpp
@@ -124,7 +124,14 @@ bool Audio::dataIsEmpty() {
 void Audio::dataFlush() {
 	data.clear();
 	data.resize(0);
+	data.reserve(sampleRate); // reserves 1 second worth of memory for new data
 }
+
+/* Returns the data found in this Audio object.  */
+std::vector<float> Audio::getAudioData() { return this->data; }
+
+/* Sets the Audio object's data to input value. */
+void Audio::setAudioData(std::vector<float> data)  { this->data = data; }
 
 /* Error handling. Called to display errors if something goes wrong with a PortAudio session.
  *

--- a/C++/Audio.h
+++ b/C++/Audio.h
@@ -1,3 +1,6 @@
+#ifndef AUDIO_H_INCLUDED
+#define AUDIO_H_INCLUDED
+
 #include "portaudio.h"
 
 #include <iostream>
@@ -20,6 +23,9 @@ class Audio {
 		bool dataIsEmpty();
 		void dataFlush();
 		
+		std::vector<float> getAudioData();
+		void setAudioData(std::vector<float>);
+
 		void error(PaError errorCode);
 
 	
@@ -32,3 +38,5 @@ class Audio {
 		PaStream *stream = NULL;
 
 };
+
+#endif

--- a/C++/AudioFeatures.cpp
+++ b/C++/AudioFeatures.cpp
@@ -1,0 +1,33 @@
+#include "AudioFeatures.h"
+
+AudioFeatures::AudioFeatures(int channelCount, int sampleRate, int framesPerBuffer)
+	: Audio(channelCount, sampleRate, framesPerBuffer) { };
+
+AudioFeatures::~AudioFeatures() { };
+
+/* From data, determine the likely pitch at each sample using the pYIN algorithm.
+ * This algorithm uses the source at: https://code.soundsoftware.ac.uk/projects/pyin,
+ * which was developed by Matthias Mauch and Simon Dixon at Queen Mary, University of London.
+ *
+ *
+ *
+ *
+ */
+void AudioFeatures::processPitches() {
+	Yin *y = new Yin(this->framesPerBuffer, this->sampleRate);
+	
+	// Existing pYIN code requires doubles.
+	// Unfortunately, doubles are not a supported type from PortAudio, so we just make a copy
+	// in memory of the data vector, but with doubles instead of floats to be able to process.
+	std::vector<double> dataAsDoubles(data.begin(), data.end());
+
+	double* ptr = dataAsDoubles.data();
+
+	for (int i=0; i<dataAsDoubles.size(); i++) {
+		Yin::YinOutput output = y->process(ptr);
+		std::cout << output.f0 << "\n";
+		ptr = ptr + 1;
+	}
+	delete y;
+	return;
+}

--- a/C++/AudioFeatures.h
+++ b/C++/AudioFeatures.h
@@ -1,0 +1,24 @@
+#include "Audio.h"
+
+#include "pyin/Yin.h"
+#include "pyin/YinUtil.h"
+
+struct Pitch {
+	double f0;
+	std::string name;
+	double rms;
+};
+
+class AudioFeatures : public Audio {
+
+	public:
+		AudioFeatures(int channelCount, int sampleRate, int framesPerBuffer);
+		~AudioFeatures();
+
+		void processPitches();
+
+
+	private:
+		std::vector<Pitch> pitches;		
+
+};


### PR DESCRIPTION
Important Notes:

- Audio.h now has an include guard. This was because when importing both AudioUtil.h and AudioFeatures.h into main, the Audio class was throwing redefinition errors.

- Data is now mutable from outside the Audio object. This is because I needed the same data for both my AudioUtil and AudioFeatures object, and the only way I could come up with a way to do that was to set it from outside the classes.

- Process pitches is obviously very incomplete.