### PR TITLE
Zero crossing rate function update and unit test

### DIFF
--- a/include/SignalProcessing.h
+++ b/include/SignalProcessing.h
@@ -6,6 +6,7 @@
 #include <complex>
 #include <vector>
 #include <valarray>
+
 const double PI = 3.141592653589793238460;
 
 class Signal {
@@ -17,5 +18,11 @@ class Signal {
 
 };
 
-template <typename T> int sgn(T val);
+template <class T> int sgn(T val ) 
+{
+	int out;
+	(val < 0) ? out = -1 : out = 1;
+	return out;
+}	
+
 #endif

--- a/src/SignalProcessing.cpp
+++ b/src/SignalProcessing.cpp
@@ -1,7 +1,8 @@
 #include "SignalProcessing.h"
 
-/* Returns the zero crossing rate of a frame. More information about zero-crossing rate can be
- * found here: https://en.wikipedia.org/wiki/Zero-crossing_rate
+/* Returns the zero crossing rate of a frame. The formula for this was found in the paper:
+ * "Separation of voiced and unvoiced using Zero Crossing Rate and Energy of the speech signal"
+ * by authors Bachu R.G., Kopparthi S., Adapa B., and Barkana B.D.
  *
  * PARAMS: in (float*) - pointer to the first element in a frame
  * 	   frameSize (int) - size of the frame
@@ -12,14 +13,19 @@
  */
 double Signal::zeroCrossingRate(float* in, int frameSize) {
 	
-	int numOfZeroCrosses = 0;
-	for (int t=1; t<frameSize-1; t++) {
-		int zerocross = sgn(in);
-		if (zerocross) { numOfZeroCrosses++; }
-		in++;
+	double zcr = 0;
+	for (int n=0; n<(frameSize - 1); n++) {
+		int sgn1 = sgn(*(in + 1));
+		int sgn2 = sgn(*in);
+
+		double zc = std::abs(sgn1 - sgn2);
+		zc = zc / (2 * frameSize);
+		zcr += zc;
+		
+		in += 1; 
 	}	
 
-	return (numOfZeroCrosses / (frameSize - 1.0));
+	return zcr;
 }
 
 /*
@@ -45,15 +51,3 @@ void Signal::FFT(std::vector<float>& data) {
 
 }
 
-/* For float values, checks if the values of the current float and the next float have different
- * signs. This is useful for checking the zeroCrossingRate.
- *
- * PARAMS: curr (float) - current float item
- * 	   next (float) - next float item
- *
- * RETURNS: If sign has changed, return true. If not, return false. *
- *
- */
-template <typename T> int sgn(T val) {
-	return (T(0) < val) - (val < T(0));
-}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,11 +18,11 @@ foreach(testSrc ${TEST_SRCS})
 	target_link_libraries(${testName} ${Boost_LIBRARIES} helper_files ${EXTRA_LIBS})
 
 	set_target_properties(${testName} PROPERTIES
-		RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testBin)
+		RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/build/test)
 
 	add_test(NAME ${testName}
-		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testBin
-		COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/testBin/${testName})
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/build/test
+		COMMAND ${CMAKE_SOURCE_DIR}/build/test/${testName})
 
 endforeach(testSrc)
 

--- a/test/TestSignalProcessing.cpp
+++ b/test/TestSignalProcessing.cpp
@@ -4,18 +4,31 @@
 
 #include <boost/test/unit_test.hpp>
 #include "SignalProcessing.h"
-#include <iostream>
 
+
+BOOST_AUTO_TEST_CASE (sign)
+{
+
+	int pos = 5;
+	int posSign = sgn(pos);
+	BOOST_CHECK(posSign == 1);
+
+	int neg = -5;
+	int negSign = sgn(neg);
+
+	BOOST_CHECK(negSign == -1);
+
+}	
 
 BOOST_AUTO_TEST_CASE (zeroCrossingRate)
 {
 
-	float exampleFrame [8] = {-1, 1, -1, 1, -1, 1, -1, 1};
-	int frameSize = 8;
+	float exampleFrame [10] = {-1, 1, 1, -1, 1, 1, -1, 1, 1, -1};
+	int frameSize = 10;
 	float *ptr = exampleFrame;
 
-	std::cout << Signal::zeroCrossingRate(ptr, frameSize);
-
-	BOOST_CHECK(Signal::zeroCrossingRate(ptr, frameSize) == 1);
+	double zcr = Signal::zeroCrossingRate(ptr, frameSize);
+	BOOST_CHECK(zcr == 0.6);
+	
 }	
 


### PR DESCRIPTION
Important Notes:

- For some reason, even if the signal varies its sign on every single possible frame entry, the zero crossing rate will not evaluate to 1.  This seems to match the formula given in the paper though, so I guess this is intentional?

- Moved template sgn definition into the header file. This fixed an undefined reference error when trying to call sgn() in our testing suite.